### PR TITLE
Fix GitHub Actions workflows to use claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/paper-review.yml
+++ b/.github/workflows/paper-review.yml
@@ -9,57 +9,75 @@ on:
       - 'paper/figures/**'
 
 jobs:
-  request-claude-review:
+  claude-paper-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Post Review Request Comment
-        uses: actions/github-script@v6
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          script: |
-            const prBody = context.payload.pull_request.body || '';
-            const section = prBody.match(/Section:\s*(.+)/)?.[1] || 'Unknown';
+          fetch-depth: 1
 
-            const reviewPrompts = {
-              'introduction': `@claude Please review this Introduction section for:
-                - Clear physics motivation for KRMHD solver
-                - Appropriate context on existing codes (Viriato, GS2, AstroGK)
-                - Compelling case for JAX-based implementation
-                - Smooth flow from problem to solution`,
+      - name: Run Claude Code Paper Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-              'formulation': `@claude Please review this Mathematical Formulation for:
-                - Correct KRMHD equations derivation
-                - Clear statement of assumptions (k∥ ≪ k⊥, strong guide field)
-                - Proper non-dimensionalization
-                - Conservation properties identified`,
+            Please review this pull request for a Journal of Plasma Physics paper on GANDALF, a KRMHD turbulence solver.
 
-              'numerics': `@claude Please review this Numerical Methods section for:
-                - Clear explanation of spectral methods advantages
-                - Proper description of dealiasing (2/3 rule)
-                - Time integration scheme details
-                - Boundary condition treatment`,
+            **Context:** Check CLAUDE.md for project guidelines including:
+            - JPP writing style (active voice, expert audience, quantitative focus)
+            - Scientific writing guidelines for plasma physics papers
+            - Sub-agent roles (physics-narrator, latex-equations, etc.)
 
-              'verification': `@claude Please review these Verification benchmarks for:
-                - Appropriate test case selection
-                - Clear presentation of expected vs actual results
-                - Convergence rate demonstration
-                - Quantitative error metrics`,
+            **Review Focus based on changed files:**
 
-              'default': `@claude Please review this section for:
-                - Physics correctness and completeness
-                - Mathematical rigor
-                - Notation consistency with notation.tex
-                - Appropriate citations for all claims
-                - Clear scientific writing following JPP standards`
-            };
+            If this is the **Mathematical Formulation** section, check:
+            - Correct KRMHD equations derivation from gyrokinetics
+            - Clear statement of assumptions (k⊥ρᵢ ≪ 1, k∥ ≪ k⊥, strong guide field)
+            - Proper Hermite moment expansion formulation
+            - Non-dimensionalization and normalization
+            - Dispersion relations and conservation properties
+            - All variables defined consistent with notation.tex
+            - All referenced equations numbered
 
-            const prompt = reviewPrompts[section.toLowerCase()] || reviewPrompts['default'];
+            If this is the **Introduction** section, check:
+            - Clear physics motivation for kinetic turbulence and KRMHD
+            - Appropriate context on existing codes (Viriato, GS2, AstroGK)
+            - Compelling case for JAX-based implementation on commodity hardware
+            - Smooth flow from problem statement to solution
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: prompt + `\n\nPlease check against CLAUDE.md and instructions.md for project context.`
-            });
+            If this is the **Numerical Methods** section, check:
+            - Clear explanation of spectral methods advantages
+            - Proper description of dealiasing (2/3 rule)
+            - Time integration scheme details (RK4)
+            - Boundary condition treatment
+            - Parallel/perpendicular discretization choices
+
+            If this is the **Verification** section, check:
+            - Appropriate benchmark selection (Alfvén waves, Orszag-Tang, turbulent spectra)
+            - Clear presentation of expected vs actual results
+            - Convergence rate demonstration
+            - Quantitative error metrics
+
+            **General checks for all sections:**
+            - Physics correctness and completeness
+            - Mathematical rigor appropriate for JPP audience
+            - Notation consistency with paper/notation.tex
+            - All claims supported by citations
+            - Active voice, present tense for methods
+            - No undefined terms or notation
+
+            Use `gh pr comment` to post your review findings. Be constructive and specific about any issues found.
+
+          # Allow Claude to use gh commands for posting reviews
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'


### PR DESCRIPTION
## Problem

The existing GitHub Actions workflows were fundamentally broken:

- **`paper-review.yml`** used `github-script` to post a comment mentioning "@claude"
- **No workflow existed** to respond to @claude mentions
- Comments posted successfully but **nothing happened** - Claude never responded
- Based on incorrect assumption that @claude mentions would automatically trigger something

## Solution

Replace with the **official Anthropic `claude-code-action`** approach, matching the working setup in the [gandalf repo](https://github.com/anjor/gandalf).

## Changes

### 1. **Replaced `.github/workflows/paper-review.yml`**

**Before:** 
- Used `github-script` to post @claude comment
- Required `pull-requests: write`, `issues: write` permissions
- Posted but never responded

**After:**
- Uses `anthropics/claude-code-action@v1`
- Claude directly reviews PRs and posts comments using `gh pr comment`
- Section-specific review criteria for JPP paper:
  - **Mathematical Formulation**: equations, gyrokinetic assumptions, notation consistency
  - **Introduction**: physics motivation, JAX rationale, context
  - **Numerical Methods**: spectral methods, dealiasing, time integration
  - **Verification**: benchmarks, convergence, error metrics
- Checks `CLAUDE.md` for writing guidelines

**Trigger:** PR opened/synced with changes to `paper/**/*.tex`, `paper/**/*.bib`, or `paper/figures/**`

### 2. **Added `.github/workflows/claude.yml`** (NEW)

Responds to **@claude mentions** in:
- Issue comments
- PR review comments  
- Issue body/title
- PR review submissions

Allows manual Claude invocation for specific questions or follow-up reviews.

## Requirements

⚠️ **Action Required:** Set up `CLAUDE_CODE_OAUTH_TOKEN` secret

1. Go to https://console.anthropic.com/settings/keys
2. Generate a new OAuth token
3. Add to repo: Settings → Secrets and variables → Actions → New repository secret
4. Name: `CLAUDE_CODE_OAUTH_TOKEN`
5. Value: [your token]

## Benefits

✅ Claude **actually responds** to review requests  
✅ Direct PR comments with actionable feedback  
✅ Section-specific physics/JPP review criteria  
✅ Matches proven approach from gandalf repo  
✅ Supports both automatic reviews (PR open) and manual (@claude mention)  
✅ Can read CI results and integrate with other checks  

## Testing

After merging and configuring the token:
1. Workflows will automatically run on PR #17 (formulation section)
2. Can test @claude mentions in any issue or PR comment
3. Should see Claude post review comments directly

## References

- Official docs: https://github.com/anthropics/claude-code-action
- Working example: https://github.com/anjor/gandalf/tree/main/.github/workflows