### PR TITLE
Remove claude_code_oauth_token from workflows for GitHub App auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,8 +34,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/.github/workflows/paper-review.yml
+++ b/.github/workflows/paper-review.yml
@@ -27,7 +27,6 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

Workflows are failing with:
```
Error: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
when using direct Anthropic API
```

This happens because we're providing `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`, but that secret doesn't exist (we use the GitHub App instead).

When the action sees an empty token, it falls back to "direct API mode" and looks for ANTHROPIC_API_KEY, which also doesn't exist → error.

## Solution

**Remove the `claude_code_oauth_token` parameter** from both workflows.

When using the **Claude Code GitHub App**, authentication happens automatically via OIDC (using the `id-token: write` permission). No manual token needed.

## Changes

- `.github/workflows/paper-review.yml`: Removed `claude_code_oauth_token` line
- `.github/workflows/claude.yml`: Removed `claude_code_oauth_token` line

Both workflows now rely on GitHub App installation for auth.

## Testing

After merge, PR #17 should work - Claude will review the formulation section automatically.