### PR TITLE
Fix paper-review.yml: Add missing authentication token

### DIFF
--- a/.github/workflows/paper-review.yml
+++ b/.github/workflows/paper-review.yml
@@ -27,6 +27,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

`paper-review.yml` workflow fails with:
```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
```

## Root Cause

The workflow was missing the `claude_code_oauth_token` parameter in the action configuration. It was accidentally removed during earlier workflow updates.

## Solution

Add the missing line:
```yaml
claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

This brings `paper-review.yml` in line with `claude-code-review.yml` which already has this line and works correctly.

## Testing

After merge, the Paper Section Review workflow should work on PR #17 (and all future paper PRs).