### PR TITLE
Add Abstract and Keywords (Issue #15)

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -17,8 +17,10 @@
 \maketitle
 
 \begin{abstract}
-% Abstract here - 200 words max for JPP
+We present GANDALF, a JAX-based spectral solver for Kinetic Reduced MHD (KRMHD) turbulence designed to democratize access to plasma turbulence research. Existing production codes require specialized HPC infrastructure and compilation expertise, limiting participation to well-resourced institutions. GANDALF addresses this barrier by leveraging JAX's hardware abstraction to run transparently on laptops, desktop GPUs, and Apple Silicon without modification, enabling single-command installation via pip. We employ Fourier spectral methods in the perpendicular plane with Hermite expansion for velocity space, combined with an exponential integrating factor method that removes Alfvén wave stiffness. Verification demonstrates research-grade accuracy: linear Alfvén waves achieve machine precision (< 10$^{-15}$ relative error), the Orszag-Tang vortex conserves energy to 10$^{-6}$ over two Alfvén times, and driven turbulence reproduces the expected $k_\perp^{-5/3}$ cascade spectrum. While incurring 2--3$\times$ performance penalty versus hand-optimized CUDA implementations, GANDALF enables rapid prototyping, parameter surveys, and educational applications on commodity hardware. The code complements rather than replaces established solvers like AstroGK and Viriato, prioritizing accessibility for researchers without HPC resources. By removing infrastructure barriers while maintaining spectral accuracy, GANDALF broadens participation in fundamental plasma turbulence research, particularly benefiting students, small research groups, and institutions in developing regions.
 \end{abstract}
+
+\noindent\textbf{Keywords:} plasma turbulence, kinetic reduced MHD, spectral methods, JAX, accessible computing, Alfvénic turbulence
 
 \input{sections/introduction}
 \input{sections/formulation}


### PR DESCRIPTION
## Summary
Adds 200-word abstract and 6 keywords to complete the GANDALF paper for JPP submission.

## Changes
- **Abstract**: 195 words covering motivation, method, results, and impact
  - Motivation: Democratizing access to KRMHD turbulence research beyond HPC-dependent codes
  - Method: JAX-based Fourier spectral solver with Hermite expansion and integrating factor
  - Results: Quantitative verification (machine precision Alfvén waves, 10^-6 energy conservation, k_perp^-5/3 cascade)
  - Impact: Research-grade accuracy on commodity hardware with 2-3× performance trade-off
- **Keywords**: plasma turbulence, kinetic reduced MHD, spectral methods, JAX, accessible computing, Alfvénic turbulence

## JPP Requirements Met
- [x] Abstract ≤ 200 words (actual: 195 words)
- [x] Covers motivation, method, results, impact
- [x] 5-6 keywords selected (actual: 6)
- [x] Follows JPP style guidelines
- [x] Active voice, quantitative claims, defines KRMHD on first use

## Notes
- Used physics-narrator agent per Issue #15 specifications
- All paper sections complete, abstract was final missing component
- Ready for JPP submission after approval

Closes #15